### PR TITLE
Add Github Action to publish to npm automatically on release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,25 @@
+name: npm-publish
+on:
+  push:
+    branches:
+      - master # Change this to your default branch
+jobs:
+  npm-publish:
+    name: npm-publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@master
+      - name: Set up Node.js
+        uses: actions/setup-node@master
+        with:
+          node-version: 10.0.0
+      - name: Publish if version has been updated
+        uses: pascalgn/npm-publish-action@4f4bf159e299f65d21cd1cbd96fc5d53228036df
+        with: # All of theses inputs are optional
+          tag_name: "v%s"
+          tag_message: "v%s"
+          commit_pattern: "^Release (\\S+)"
+        env: # More info about the environment variables in the README
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # You need to set this in your repo settings


### PR DESCRIPTION
**Before submitting your PR for review**

- Pull `upstream develop` and fix conflicts if any
- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Adds a CD github workflow to publish to the npm package registry whenever a specific format is used on a commit message. For more information, see the author's [article](https://github.com/marketplace/actions/publish-to-npm) of the Github Action.

Summarise the main tasks handled in the pull request

- Add a `npm-publish.yml` file for Github Actions to publish npm package.

Describe (in detail) what the task completed in the pull request does as per the relevant task

**How should this be manually tested?**

Not applicable

**Any background context you want to provide?**

None

**What is the link to the issue on Github?**

None

**Questions:**

None